### PR TITLE
Support language-specific VTT transcripts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,36 +1,58 @@
-name: lint
+name: CI
 
 on:
   push:
-    branches:
+    branches: [ 1.0.x ]
+  pull_request:
+    branches: [ 1.0.x ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  phpcs:
-    name: Run PHPCS with Drupal Standards
-    runs-on: ubuntu-latest
-
+  build:
+    runs-on: ubuntu-24.04
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ["8.3", "8.4"]
+        test-suite: ["functional-javascript"]
+        drupal-version: ["10.5", "10.6", "11.2", "11.3"]
+    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | test-suite ${{ matrix.test-suite }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
-    - name: Set up PHP and Composer
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.3'
-        tools: phpcs
-        coverage: none
+      - name: create docker network
+        run: docker network create ci-default
 
-    - name: Install Drupal Coder Standards
-      run: |
-        composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-        composer global require --no-interaction drupal/coder slevomat/coding-standard
-        COMPOSER_HOME=$(composer config --global home)
-        phpcs --config-set installed_paths \
-          "$COMPOSER_HOME/vendor/drupal/coder/coder_sniffer,$COMPOSER_HOME/vendor/slevomat/coding-standard"
-        phpcs -i
+      - name: Start chromedriver
+        if: matrix.test-suite == 'functional-javascript'
+        run: |-
+          docker run -d \
+            --name chromedriver \
+            --network ci-default \
+            drupalci/webdriver-chromedriver:production \
+            chromedriver --log-path=/dev/null --verbose --allowed-ips= --allowed-origins=*
 
-    - name: Run PHPCS
-      run: phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme --ignore=vendor/ ./
+      - name: PHPUNIT tests
+        run: |
+          docker run \
+            --rm \
+            --name drupal \
+            --hostname drupal \
+            --volume $(pwd):/var/www/drupal/web/modules/contrib/$MODULE_NAME:ro \
+            --env ENABLE_MODULES \
+            --env TEST_SUITE \
+            --network ci-default \
+           ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
+        env:
+          MODULE_NAME: islandora_vtt
+          ENABLE_MODULES: islandora_vtt
+          TEST_SUITE: ${{ matrix.test-suite }}
 
-    - name: Run DrupalPractice
-      run: phpcs --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme --ignore=vendor/ ./
+      - name: Print chromedriver logs
+        if: matrix.test-suite == 'functional-javascript'
+        run: docker logs chromedriver

--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,8 @@
     "support": {
         "issues": "https://www.drupal.org/project/issues/islandora_vtt",
         "source": "https://www.drupal.org/project/islandora_vtt"
+    },
+    "require": {
+        "drupal/islandora": "^2.18.3"
     }
 }

--- a/config/schema/islandora_vtt.schema.yml
+++ b/config/schema/islandora_vtt.schema.yml
@@ -1,0 +1,31 @@
+action.configuration.generate_ocr_derivative:
+  type: mapping
+  label: 'Generate OCR derivative action configuration'
+  mapping:
+    queue:
+      type: string
+      label: 'Queue'
+    event:
+      type: string
+      label: 'Event'
+    source_term_uri:
+      type: uri
+      label: 'Source term URI'
+    derivative_term_uri:
+      type: uri
+      label: 'Derivative term URI'
+    mimetype:
+      type: string
+      label: 'MIME type'
+    args:
+      type: string
+      label: 'Arguments'
+    destination_media_type:
+      type: string
+      label: 'Destination media type'
+    scheme:
+      type: string
+      label: 'File scheme'
+    path:
+      type: string
+      label: 'Path'

--- a/islandora_vtt.libraries.yml
+++ b/islandora_vtt.libraries.yml
@@ -1,5 +1,5 @@
 vtt:
-  version: 1.0.0
+  version: 1.1.0
   js:
     js/vtt.js: {}
   css:
@@ -9,4 +9,5 @@ vtt:
     - core/jquery
     - core/drupal
     - core/drupalSettings
+    - core/once
     - core/jquery.once

--- a/islandora_vtt.module
+++ b/islandora_vtt.module
@@ -4,6 +4,7 @@
  * @file
  * Contains islandora_vtt.module.
  */
+
 use Drupal\Core\Hook\Attribute\LegacyHook;
 use Drupal\islandora_vtt\Hook\IslandoraVttHooks;
 use Drupal\media\Entity\Media;
@@ -20,31 +21,93 @@ function islandora_vtt_theme($existing, $type, $theme, $path) {
  * Implements hook_preprocess_media().
  */
 #[LegacyHook]
-function islandora_vtt_preprocess_media(&$vars)
-{
-    \Drupal::service(IslandoraVttHooks::class)->preprocessMedia($vars);
+function islandora_vtt_preprocess_media(&$vars) {
+  \Drupal::service(IslandoraVttHooks::class)->preprocessMedia($vars);
 }
 
 /**
- * Helper function to get a media's sibling VTT URL.
+ * Helper function to get a media's sibling VTT files.
+ */
+function islandora_vtt_get_vtts($media) {
+  $rows = islandora_vtt_get_vtt_file_rows($media);
+  if (empty($rows)) {
+    return [];
+  }
+
+  $mids = array_column($rows, 'mid');
+  return Media::loadMultiple($mids);
+}
+
+/**
+ * Helper function to get VTT file rows from the current node.
+ */
+function islandora_vtt_get_vtt_file_rows($media) {
+  $node_id = islandora_vtt_get_node_id($media);
+  if (!$node_id) {
+    return [];
+  }
+
+  $tid = islandora_vtt_extracted_text_tid();
+  if (!$tid) {
+    return [];
+  }
+
+  $query = \Drupal::database()->select('media_field_data', 'mfd');
+  $query->join('media__field_media_of', 'mo', 'mo.entity_id = mfd.mid');
+  $query->join('media__field_media_use', 'u', 'u.entity_id = mfd.mid');
+  $query->join('media__field_media_file', 'f', 'f.entity_id = mfd.mid');
+  $query->join('file_managed', 'fm', 'fm.fid = f.field_media_file_target_id');
+  $query
+    ->fields('mfd', ['mid', 'bundle', 'langcode']);
+  $query->addField('f', 'field_media_file_target_id', 'fid');
+  $query->addField('fm', 'uri', 'uri');
+  $query->addField('fm', 'filename', 'filename');
+  $rows = $query
+    ->condition('mo.deleted', 0)
+    ->condition('u.deleted', 0)
+    ->condition('f.deleted', 0)
+    ->condition('mfd.bundle', 'extracted_text')
+    ->condition('mo.field_media_of_target_id', $node_id)
+    ->condition('u.field_media_use_target_id', $tid)
+    ->orderBy('mfd.langcode')
+    ->orderBy('mfd.mid')
+    ->execute()
+    ->fetchAllAssoc('mid');
+
+  if (empty($rows)) {
+    return [];
+  }
+
+  $media_by_id = Media::loadMultiple(array_keys($rows));
+  return array_filter($rows, static function ($row) use ($media_by_id) {
+    return isset($media_by_id[$row->mid]) && $media_by_id[$row->mid]->access('view');
+  });
+}
+
+/**
+ * Helper function to get the node ID that should own the VTT media.
+ */
+function islandora_vtt_get_node_id($media) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if (is_object($node) && $node->id()) {
+    return $node->id();
+  }
+  if (is_numeric($node)) {
+    return $node;
+  }
+  if ($media->hasField('field_media_of') && !$media->field_media_of->isEmpty()) {
+    return $media->field_media_of->target_id;
+  }
+
+  return NULL;
+}
+
+/**
+ * Helper function to get the first media sibling VTT file.
  */
 function islandora_vtt_get_vtt($media) {
-  $mid = \Drupal::database()->query("SELECT mid
-    FROM {media__field_media_of} mo
-    INNER JOIN {media__field_media_use} u ON u.entity_id = mo.entity_id
-    INNER JOIN {media_field_data} m ON m.mid = mo.entity_id
-    WHERE mo.bundle = 'extracted_text'
-      AND field_media_use_target_id = :tid
-      AND field_media_of_target_id = :mid", [
-        ':mid' => $media->field_media_of->target_id,
-        ':tid' => islandora_vtt_extracted_text_tid(),
-      ])->fetchField();
-  $vtt = $mid ? Media::load($mid) : FALSE;
-  return $vtt
-    && $vtt->access('view')
-    && !is_null($vtt->field_media_file)
-    && !$vtt->field_media_file->isEmpty()
-    && !is_null($vtt->field_media_file->entity) ? $vtt : FALSE;
+  $vtts = islandora_vtt_get_vtts($media);
+  return reset($vtts) ?: FALSE;
 }
 
 /**

--- a/js/vtt.js
+++ b/js/vtt.js
@@ -1,234 +1,393 @@
 (function ($, Drupal, drupalSettings) {
-    Drupal.behaviors.islandoraVtt = {
-      cues: [],
-      currentSearchIndex: 0,
-      searchResults: [],
-      attach: function (context, settings) {
-        function isValidString(inputString) {
-          return /^[A-Za-z0-9-_"' ?]+$/.test(inputString);
+  Drupal.behaviors.islandoraVtt = {
+    cues: [],
+    currentSearchIndex: 0,
+    searchResults: [],
+    currentTranscript: null,
+    currentVttText: '',
+
+    attach: function (context) {
+      const transcripts = drupalSettings.vttTranscripts || [];
+
+      if (!transcripts.length) {
+        return;
+      }
+
+      if (!once('vtt-transcript-root', '#transcript', context).length) {
+        return;
+      }
+
+      $(once('vtt-search-shortcut', 'body')).on('keypress', (e) => {
+        if (e.key !== ' ' || ['INPUT', 'SELECT', 'TEXTAREA', 'BUTTON'].includes(e.target.tagName)) {
+          return;
         }
-  
-        $(once('vtt-search', 'body')).on('keypress', function(e) {
-          if (e.key === " ") {
-            const player = document.querySelector(drupalSettings.vttPlayerType);
-            if (player.paused) {
-              player.play().catch((error) => {
-                console.error('Audio playback failed:', error);
-              });
-            } else {
-              player.pause();
-            }
-          }
-        })
-        $(once('vtt-pager', '#prevBtn, #nextBtn')).on('click', function() {
-          if ($(this).attr('id') == 'prevBtn') {
-            Drupal.behaviors.islandoraVtt.navigateSearchResults(-1)
-          } else {
-            Drupal.behaviors.islandoraVtt.navigateSearchResults(1)
-          }
-        });
-        $(once('vtt-search', '#searchInput')).on('keypress', function(e) {
-          if (e.key === "Enter") {
-            Drupal.behaviors.islandoraVtt.searchTranscript();
-          }
-        });
-        $(once('vtt-search-btn', '#vtt-search-btn')).on('click', function() {
-          Drupal.behaviors.islandoraVtt.searchTranscript();
-        });
-        const fetchVTT = async () => {
-          for (let i = 0; i < 5; i++) {
-            try {
-              const response = await fetch(drupalSettings.vttUrl);
-              if (!response.ok) throw new Error('Failed to fetch VTT file');
-              const vttText = await response.text();
-              const player = document.querySelector(drupalSettings.vttPlayerType);
-              if (!player) throw new Error('Player element not found');
-
-              this.parseVTT(vttText);
-              this.createTranscript();
-
-              player.addEventListener('timeupdate', () => {
-                this.highlightCue();
-              });
-
-              var s = Drupal.behaviors.lehighNode.getQueryParam('search_api_fulltext');
-              if (s != null && s != "" && isValidString(s) && vttText.toLowerCase().includes(s.toLowerCase())) {
-                $('#searchInput').attr('value', s);
-                $('#vtt-search-btn').click();
-                const player = document.querySelector(drupalSettings.vttPlayerType);
-                player.pause();
-              }
-              $('#block-views-block-item-title-title-area .internal-links').append('<a href="#transcript">Transcript</a>')
-              break;
-            } catch (error) {
-              await new Promise(resolve => setTimeout(resolve, 1000));
-            }
-          }
-        };
-  
-        // Automatically fetch VTT when behavior is attached
-        fetchVTT();
-      },
-  
-      // Make parseVTT callable from outside
-      parseVTT: function (vtt) {
-        let cue = {}
-        const lines = vtt.split('\n').filter(line => line.trim() !== 'WEBVTT'); // Skip the WEBVTT line  
-        lines.forEach(line => {
-          if (line.includes('-->')) {
-            const [start, end] = line.split(' --> ');
-            cue.start = this.parseTime(start);
-            cue.end = this.parseTime(end);
-          } else if (line.trim()) {
-            cue.text = line;
-            this.cues.push({ ...cue });
-            cue = {};
-          }
-        });
-      },
-  
-      parseTime: function (timeString) {
-        const parts = timeString.split(':');
-        return (
-          parseInt(parts[0], 10) * 3600 +
-          parseInt(parts[1], 10) * 60 +
-          parseFloat(parts[2])
-        );
-      },
-  
-      createTranscript: function () {
-        const transcriptBox = document.getElementById('transcriptBox');
-        transcriptBox.innerHTML = '';
-        this.cues.forEach((cue, index) => {
-          const cueElement = document.createElement('div');
-          cueElement.classList.add('cue');
-          cueElement.innerHTML = `
-            <a href="#" data-start="${cue.start}">
-              ${this.formatTime(cue.start)}
-            </a>
-            <span>${cue.text}</span>
-          `;
-          cueElement.id = `cue-${index}`;
-          transcriptBox.appendChild(cueElement);
-        });
-
-        $("a[data-start]").on('click', function() {
-          const start=$(this).attr('data-start');
-          Drupal.behaviors.islandoraVtt.jumpTo(start);
-        });
-      },
-  
-      formatTime: function (time) {
-        const minutes = Math.floor(time / 60);
-        const seconds = Math.floor(time % 60);
-        return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
-      },
-  
-      jumpTo: function (time) {
-        const player = document.querySelector(drupalSettings.vttPlayerType);
-        player.currentTime = time;
+        const player = this.getPlayer();
+        if (!player) {
+          return;
+        }
         if (player.paused) {
           player.play().catch((error) => {
             console.error('Audio playback failed:', error);
           });
         }
-        return false;
-      },
-  
-      highlightCue: function () {
-        const player = document.querySelector(drupalSettings.vttPlayerType);
-        const currentTime = player.currentTime;
-        const transcriptBox = document.getElementById('transcriptBox');
-
-        this.cues.forEach((cue, index) => {
-          const cueElement = document.getElementById(`cue-${index}`);
-          if (currentTime >= cue.start && currentTime <= cue.end) {
-            cueElement.classList.add('highlight');
-            transcriptBox.scrollTo({
-              top: cueElement.offsetTop - transcriptBox.offsetTop,
-              behavior: 'smooth'
-            });
-          } else {
-            cueElement.classList.remove('highlight');
-          }
-        });
-      },
-
-      searchTranscript: function () {
-        const searchInput = document.getElementById('searchInput').value.toLowerCase();
-        const cueElements = document.querySelectorAll('.cue');
-        const player = document.querySelector(drupalSettings.vttPlayerType);
-
-        // Clear previous highlights and search results
-        cueElements.forEach((cue) => {
-          cue.querySelector('span').innerHTML = cue.querySelector('span').textContent; // Remove previous highlights
-        });
-  
-        // Find and highlight matching text
-        cueElements.forEach((cue, index) => {
-          const text = cue.querySelector('span').textContent.toLowerCase();
-          if (text.includes(searchInput)) {
-            this.searchResults.push({ cueIndex: index, searchTerm: searchInput });
-          }
-        });
-  
-        if (this.searchResults.length > 0) {
-            this.updateSearchResult();
-            document.getElementById('nextBtn').disabled = this.searchResults.length <= 1;
-            document.getElementById('prevBtn').disabled = this.currentSearchIndex == 0;
-            if (player.paused) {
-                player.play().catch(error => {
-                    console.error('Playback failed:', error);
-                });
-            }
-        } else {
-            document.getElementById('pagerInfo').textContent = '0 of 0 results';
-            document.getElementById('nextBtn').disabled = true;
-            document.getElementById('prevBtn').disabled = true;
+        else {
+          player.pause();
         }
-      },
-  
-      updateSearchResult: function () {
-        const cueElements = document.querySelectorAll('.cue');
- 
-        // Clear all previous highlights
-        cueElements.forEach((cue) => {
-          cue.querySelector('span').innerHTML = cue.querySelector('span').textContent;
-        });
-  
-        // Highlight the current search result
-        const { cueIndex, searchTerm } = this.searchResults[this.currentSearchIndex];
-        const cueElement = document.getElementById(`cue-${cueIndex}`);
-        const cueText = cueElement.querySelector('span').textContent;
-  
-        // Highlight the matching word(s) in the text
-        const regex = new RegExp(`(${searchTerm})`, 'gi');
-        const highlightedText = cueText.replace(regex, '<mark>$1</mark>');
-        cueElement.querySelector('span').innerHTML = highlightedText;
-  
-        cueElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  
-        // Skip audio to the start of the corresponding cue
-        this.jumpTo(this.cues[cueIndex].start);
+      });
 
-        document.getElementById('nextBtn').disabled = this.searchResults.length == (this.currentSearchIndex+1);
-        document.getElementById('prevBtn').disabled = this.currentSearchIndex == 0 && this.searchResults.length > 0;
-
-        document.getElementById('pagerInfo').textContent = `${this.currentSearchIndex + 1} of ${this.searchResults.length} results`;
-      },
-  
-      navigateSearchResults: function (direction) { 
-        this.currentSearchIndex += direction;
-  
-        // Bound the index within the search results
-        if (this.currentSearchIndex < 0) {
-          this.currentSearchIndex = 0;
-        } else if (this.currentSearchIndex >= this.searchResults.length) {
-          this.currentSearchIndex = this.searchResults.length - 1;
+      $(once('vtt-pager', '#prevBtn, #nextBtn', context)).on('click', (e) => {
+        if ($(e.currentTarget).attr('id') === 'prevBtn') {
+          this.navigateSearchResults(-1);
         }
-  
-        // Update the view and jump audio to the result
-        this.updateSearchResult();
+        else {
+          this.navigateSearchResults(1);
+        }
+      });
+
+      $(once('vtt-search-input', '#searchInput', context)).on('keypress', (e) => {
+        if (e.key === 'Enter') {
+          this.searchTranscript();
+        }
+      });
+
+      $(once('vtt-search-btn', '#vtt-search-btn', context)).on('click', () => {
+        this.searchTranscript();
+      });
+
+      $(once('vtt-language-select', '#vttLanguageSelect', context)).on('change', (e) => {
+        const selected = transcripts.find((transcript) => String(transcript.id) === e.target.value);
+        if (selected) {
+          this.loadTranscript(selected);
+        }
+      });
+
+      this.buildLanguageControl(transcripts);
+      this.loadTranscript(transcripts[0]);
+    },
+
+    buildLanguageControl: function (transcripts) {
+      const languageControl = document.getElementById('vttLanguageControl');
+      const languageSelect = document.getElementById('vttLanguageSelect');
+      if (!languageControl || !languageSelect) {
+        return;
       }
-    };
+
+      languageSelect.innerHTML = '';
+      transcripts.forEach((transcript, index) => {
+        const option = document.createElement('option');
+        option.value = String(transcript.id || index);
+        option.textContent = transcript.label || transcript.langcode || 'Transcript';
+        languageSelect.appendChild(option);
+        transcript.id = option.value;
+      });
+
+      languageControl.classList.toggle('d-none', transcripts.length <= 1);
+    },
+
+    loadTranscript: async function (transcript) {
+      this.currentTranscript = transcript;
+      this.resetState();
+      this.updateDownloadLink(transcript);
+
+      for (let i = 0; i < 5; i++) {
+        try {
+          const response = await fetch(transcript.url);
+          if (!response.ok) {
+            throw new Error('Failed to fetch VTT file');
+          }
+
+          this.currentVttText = await response.text();
+          const player = this.getPlayer();
+          if (!player) {
+            throw new Error('Player element not found');
+          }
+
+          this.parseVTT(this.currentVttText);
+          this.createTranscript();
+          this.attachPlayerHighlight(player);
+          this.applyInitialSearch();
+          this.addTranscriptAnchor();
+          break;
+        }
+        catch (error) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+      }
+    },
+
+    resetState: function () {
+      this.cues = [];
+      this.searchResults = [];
+      this.currentSearchIndex = 0;
+      this.currentVttText = '';
+
+      const transcriptBox = document.getElementById('transcriptBox');
+      if (transcriptBox) {
+        transcriptBox.innerHTML = '';
+      }
+      const pagerInfo = document.getElementById('pagerInfo');
+      if (pagerInfo) {
+        pagerInfo.textContent = '';
+      }
+      const nextBtn = document.getElementById('nextBtn');
+      const prevBtn = document.getElementById('prevBtn');
+      if (nextBtn) {
+        nextBtn.disabled = true;
+      }
+      if (prevBtn) {
+        prevBtn.disabled = true;
+      }
+    },
+
+    updateDownloadLink: function (transcript) {
+      const downloadBtn = document.getElementById('vttDownloadBtn');
+      if (!downloadBtn) {
+        return;
+      }
+
+      downloadBtn.href = transcript.url;
+      downloadBtn.download = transcript.filename || `${transcript.langcode || 'transcript'}.vtt`;
+    },
+
+    attachPlayerHighlight: function (player) {
+      if (player.dataset.vttTimeupdateAttached) {
+        return;
+      }
+      player.dataset.vttTimeupdateAttached = 'true';
+      player.addEventListener('timeupdate', () => {
+        this.highlightCue();
+      });
+    },
+
+    applyInitialSearch: function () {
+      if (!Drupal.behaviors.lehighNode || !Drupal.behaviors.lehighNode.getQueryParam) {
+        return;
+      }
+
+      const searchValue = Drupal.behaviors.lehighNode.getQueryParam('search_api_fulltext');
+      if (searchValue && this.isValidString(searchValue) && this.currentVttText.toLowerCase().includes(searchValue.toLowerCase())) {
+        $('#searchInput').val(searchValue);
+        this.searchTranscript();
+        const player = this.getPlayer();
+        if (player) {
+          player.pause();
+        }
+      }
+    },
+
+    addTranscriptAnchor: function () {
+      const internalLinks = $('#block-views-block-item-title-title-area .internal-links');
+      if (internalLinks.length && !internalLinks.find('a[href="#transcript"]').length) {
+        internalLinks.append('<a href="#transcript">Transcript</a>');
+      }
+    },
+
+    isValidString: function (inputString) {
+      return /^[A-Za-z0-9-_"' ?]+$/.test(inputString);
+    },
+
+    getPlayer: function () {
+      return document.querySelector(drupalSettings.vttPlayerType);
+    },
+
+    parseVTT: function (vtt) {
+      let cue = {};
+      const lines = vtt.split('\n').filter((line) => line.trim() !== 'WEBVTT');
+      lines.forEach((line) => {
+        if (line.includes('-->')) {
+          const [start, end] = line.split(' --> ');
+          cue.start = this.parseTime(start);
+          cue.end = this.parseTime(end);
+          cue.text = '';
+        }
+        else if (line.trim() && cue.start !== undefined) {
+          cue.text = cue.text ? `${cue.text}\n${line}` : line;
+        }
+        else if (!line.trim() && cue.start !== undefined && cue.text) {
+          this.cues.push({ ...cue });
+          cue = {};
+        }
+      });
+
+      if (cue.start !== undefined && cue.text) {
+        this.cues.push({ ...cue });
+      }
+    },
+
+    parseTime: function (timeString) {
+      const parts = timeString.trim().split(':');
+      return (
+        parseInt(parts[0], 10) * 3600 +
+        parseInt(parts[1], 10) * 60 +
+        parseFloat(parts[2])
+      );
+    },
+
+    createTranscript: function () {
+      const transcriptBox = document.getElementById('transcriptBox');
+      if (!transcriptBox) {
+        return;
+      }
+
+      transcriptBox.innerHTML = '';
+      this.cues.forEach((cue, index) => {
+        const cueElement = document.createElement('div');
+        cueElement.classList.add('cue');
+        cueElement.id = `cue-${index}`;
+
+        const link = document.createElement('a');
+        link.href = '#';
+        link.dataset.start = cue.start;
+        link.textContent = this.formatTime(cue.start);
+
+        const text = document.createElement('span');
+        text.textContent = cue.text;
+
+        cueElement.appendChild(link);
+        cueElement.appendChild(text);
+        transcriptBox.appendChild(cueElement);
+      });
+
+      $('a[data-start]').off('click.islandoraVtt').on('click.islandoraVtt', (e) => {
+        e.preventDefault();
+        this.jumpTo($(e.currentTarget).attr('data-start'));
+      });
+    },
+
+    formatTime: function (time) {
+      const minutes = Math.floor(time / 60);
+      const seconds = Math.floor(time % 60);
+      return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+    },
+
+    jumpTo: function (time) {
+      const player = this.getPlayer();
+      if (!player) {
+        return false;
+      }
+      player.currentTime = time;
+      if (player.paused) {
+        player.play().catch((error) => {
+          console.error('Audio playback failed:', error);
+        });
+      }
+      return false;
+    },
+
+    highlightCue: function () {
+      const player = this.getPlayer();
+      const transcriptBox = document.getElementById('transcriptBox');
+      if (!player || !transcriptBox) {
+        return;
+      }
+
+      const currentTime = player.currentTime;
+      this.cues.forEach((cue, index) => {
+        const cueElement = document.getElementById(`cue-${index}`);
+        if (!cueElement) {
+          return;
+        }
+        if (currentTime >= cue.start && currentTime <= cue.end) {
+          cueElement.classList.add('highlight');
+          transcriptBox.scrollTo({
+            top: cueElement.offsetTop - transcriptBox.offsetTop,
+            behavior: 'smooth'
+          });
+        }
+        else {
+          cueElement.classList.remove('highlight');
+        }
+      });
+    },
+
+    searchTranscript: function () {
+      const searchInput = document.getElementById('searchInput').value.toLowerCase();
+      const cueElements = document.querySelectorAll('.cue');
+      const player = this.getPlayer();
+
+      this.searchResults = [];
+      this.currentSearchIndex = 0;
+      cueElements.forEach((cue) => {
+        cue.querySelector('span').textContent = cue.querySelector('span').textContent;
+      });
+
+      cueElements.forEach((cue, index) => {
+        const text = cue.querySelector('span').textContent.toLowerCase();
+        if (searchInput && text.includes(searchInput)) {
+          this.searchResults.push({ cueIndex: index, searchTerm: searchInput });
+        }
+      });
+
+      if (this.searchResults.length > 0) {
+        this.updateSearchResult();
+        document.getElementById('nextBtn').disabled = this.searchResults.length <= 1;
+        document.getElementById('prevBtn').disabled = this.currentSearchIndex === 0;
+        if (player && player.paused) {
+          player.play().catch((error) => {
+            console.error('Playback failed:', error);
+          });
+        }
+      }
+      else {
+        document.getElementById('pagerInfo').textContent = '0 of 0 results';
+        document.getElementById('nextBtn').disabled = true;
+        document.getElementById('prevBtn').disabled = true;
+      }
+    },
+
+    updateSearchResult: function () {
+      const cueElements = document.querySelectorAll('.cue');
+      cueElements.forEach((cue) => {
+        cue.querySelector('span').textContent = cue.querySelector('span').textContent;
+      });
+
+      const { cueIndex, searchTerm } = this.searchResults[this.currentSearchIndex];
+      const cueElement = document.getElementById(`cue-${cueIndex}`);
+      const textElement = cueElement.querySelector('span');
+      const cueText = textElement.textContent;
+      this.highlightText(textElement, cueText, searchTerm);
+
+      cueElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      this.jumpTo(this.cues[cueIndex].start);
+
+      document.getElementById('nextBtn').disabled = this.searchResults.length === (this.currentSearchIndex + 1);
+      document.getElementById('prevBtn').disabled = this.currentSearchIndex === 0 && this.searchResults.length > 0;
+      document.getElementById('pagerInfo').textContent = `${this.currentSearchIndex + 1} of ${this.searchResults.length} results`;
+    },
+
+    escapeRegExp: function (string) {
+      return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    },
+
+    highlightText: function (element, text, searchTerm) {
+      const fragment = document.createDocumentFragment();
+      const regex = new RegExp(this.escapeRegExp(searchTerm), 'gi');
+      let lastIndex = 0;
+      let match;
+
+      while ((match = regex.exec(text)) !== null) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+        const mark = document.createElement('mark');
+        mark.textContent = match[0];
+        fragment.appendChild(mark);
+        lastIndex = match.index + match[0].length;
+      }
+
+      fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+      element.replaceChildren(fragment);
+    },
+
+    navigateSearchResults: function (direction) {
+      this.currentSearchIndex += direction;
+
+      if (this.currentSearchIndex < 0) {
+        this.currentSearchIndex = 0;
+      }
+      else if (this.currentSearchIndex >= this.searchResults.length) {
+        this.currentSearchIndex = this.searchResults.length - 1;
+      }
+
+      this.updateSearchResult();
+    }
+  };
 })(jQuery, Drupal, drupalSettings);

--- a/src/Hook/IslandoraVttHooks.php
+++ b/src/Hook/IslandoraVttHooks.php
@@ -2,57 +2,128 @@
 
 namespace Drupal\islandora_vtt\Hook;
 
-use Drupal\media\Entity\Media;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Hook\Attribute\Hook;
+
 /**
  * Hook implementations for islandora_vtt.
  */
-class IslandoraVttHooks
-{
-    /**
-     * Implements hook_theme().
-     */
-    #[Hook('theme')]
-    public static function theme($existing, $type, $theme, $path)
-    {
-        return [
-            'vtt_transcript' => [
-                'variables' => [
-                ],
-                'template' => 'vtt-transcript',
-                'path' => $path . '/templates',
-            ],
-        ];
+class IslandoraVttHooks {
+
+  /**
+   * Implements hook_theme().
+   */
+  #[Hook('theme')]
+  public static function theme($existing, $type, $theme, $path) {
+    return [
+      'vtt_transcript' => [
+        'variables' => [],
+        'template' => 'vtt-transcript',
+        'path' => $path . '/templates',
+      ],
+    ];
+  }
+
+  /**
+   * Implements hook_preprocess_media().
+   */
+  #[Hook('preprocess_media')]
+  public static function preprocessMedia(&$vars) {
+    if (!in_array($vars['view_mode'], [
+      'full',
+      'default_islandora_display',
+    ])) {
+      return;
     }
-    /**
-     * Implements hook_preprocess_media().
-     */
-    #[Hook('preprocess_media')]
-    public static function preprocessMedia(&$vars)
-    {
-        if (!in_array($vars['view_mode'], [
-            'full',
-            'default_islandora_display',
-        ])) {
-            return;
-        }
-        $media = $vars['media'];
-        if (empty($media) || !in_array($media->bundle(), [
-            'audio',
-            'video',
-        ])) {
-            return;
-        }
-        $vtt = islandora_vtt_get_vtt($media);
-        if (!$vtt) {
-            return;
-        }
-        $vars['content']['vtt'] = [
-            '#theme' => 'vtt_transcript',
-            '#weight' => 100,
-        ];
-        $vars['#attached']['library'][] = 'islandora_vtt/vtt';
-        $vars['#attached']['drupalSettings']['vttUrl'] = $vtt->field_media_file->entity->createFileUrl();
-        $vars['#attached']['drupalSettings']['vttPlayerType'] = $media->bundle();
+    $media = $vars['media'];
+    if (empty($media) || !in_array($media->bundle(), [
+      'audio',
+      'video',
+    ])) {
+      return;
     }
+    $vtt_files = islandora_vtt_get_vtt_file_rows($media);
+    if (empty($vtt_files)) {
+      return;
+    }
+    $transcripts = [];
+    $cacheability = CacheableMetadata::createFromObject($media);
+    $node = \Drupal::routeMatch()->getParameter('node');
+    if (is_object($node)) {
+      $cacheability->addCacheableDependency($node);
+    }
+    elseif (!$media->field_media_of->isEmpty() && $media->field_media_of->entity) {
+      $cacheability->addCacheableDependency($media->field_media_of->entity);
+    }
+    $language_manager = \Drupal::languageManager();
+    $file_url_generator = \Drupal::service('file_url_generator');
+    $media_storage = \Drupal::entityTypeManager()->getStorage('media');
+    $file_storage = \Drupal::entityTypeManager()->getStorage('file');
+    foreach ($vtt_files as $vtt_file) {
+      $vtt = $media_storage->load($vtt_file->mid);
+      $file = $file_storage->load($vtt_file->fid);
+      if (!$vtt) {
+        continue;
+      }
+      $cacheability
+        ->addCacheableDependency($vtt);
+      if ($file) {
+        $cacheability->addCacheableDependency($file);
+      }
+      $langcode = $vtt_file->langcode;
+      $language = $language_manager->getLanguage($langcode);
+      $label = $language ? $language->getName() : $langcode;
+      $filename = $vtt_file->filename ?: ('transcript-' . $langcode . '.vtt');
+      if (!preg_match('/\.vtt$/i', $filename)) {
+        $filename = preg_replace('/\.[^.]+$/', '', $filename) . '.vtt';
+      }
+      $transcripts[] = [
+        'id' => $vtt_file->mid,
+        'url' => static::buildTranscriptFileUrl($vtt_file->uri, $file_url_generator),
+        'fileUri' => $vtt_file->uri,
+        'langcode' => $langcode,
+        'label' => $label,
+        'filename' => $filename,
+      ];
+    }
+    if (empty($transcripts)) {
+      return;
+    }
+    $vars['content']['vtt'] = [
+      '#theme' => 'vtt_transcript',
+      '#weight' => 100,
+    ];
+    $vars['#attached']['library'][] = 'islandora_vtt/vtt';
+    $vars['#attached']['drupalSettings']['vttTranscripts'] = $transcripts;
+    $vars['#attached']['drupalSettings']['vttPlayerType'] = $media->bundle();
+    $cacheability->applyTo($vars);
+  }
+
+  /**
+   * Builds the browser URL for a transcript file URI.
+   *
+   * @param string $file_uri
+   *   The file entity URI.
+   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
+   *   The file URL generator service.
+   *
+   * @return string
+   *   The absolute browser URL.
+   */
+  protected static function buildTranscriptFileUrl(
+    string $file_uri,
+    FileUrlGeneratorInterface $file_url_generator,
+  ): string {
+    if (str_starts_with($file_uri, 'private://')) {
+      $path = substr($file_uri, strlen('private://'));
+      $path = implode('/', array_map('rawurlencode', explode('/', $path)));
+      $base_path = rtrim(\Drupal::request()->getBasePath(), '/');
+
+      return \Drupal::request()->getSchemeAndHttpHost() . $base_path . '/system/files/' . $path;
+    }
+
+    return $file_url_generator->generateAbsoluteString($file_uri);
+  }
+
 }

--- a/src/Hook/IslandoraVttHooks.php
+++ b/src/Hook/IslandoraVttHooks.php
@@ -32,6 +32,7 @@ class IslandoraVttHooks {
   public static function preprocessMedia(&$vars) {
     if (!in_array($vars['view_mode'], [
       'full',
+      'default',
       'default_islandora_display',
     ])) {
       return;

--- a/templates/vtt-transcript.html.twig
+++ b/templates/vtt-transcript.html.twig
@@ -1,4 +1,4 @@
-<div id="transcript" class="d-flex mt-3 mb-3 align-items-center">
+<div id="transcript" class="d-flex mt-3 mb-3 align-items-center flex-wrap">
   <div class="d-flex align-items-center me-5">
     <div class="input-group me-auto">
       <input type="text" id="searchInput" class="form-control" placeholder="Search transcript...">
@@ -13,11 +13,18 @@
       </div>
   </div>
 
-  <div class="d-flex justify-content-center align-items-center">
+  <div class="d-flex justify-content-center align-items-center me-5">
     <button id="prevBtn" class="btn btn-secondary me-2 trigger" disabled>&lt;</button>
     <span id="pagerInfo"></span>
     <button id="nextBtn" class="btn btn-secondary ms-2 trigger" disabled>&gt;</button>
   </div>
+
+  <div id="vttLanguageControl" class="d-flex align-items-center me-3 d-none">
+    <label for="vttLanguageSelect" class="visually-hidden">Transcript language</label>
+    <select id="vttLanguageSelect" class="form-select"></select>
+  </div>
+
+  <a id="vttDownloadBtn" class="btn btn-secondary" href="#" download>Download transcript</a>
 </div>
 
 <div class="card">

--- a/tests/modules/islandora_vtt_test/islandora_vtt_test.info.yml
+++ b/tests/modules/islandora_vtt_test/islandora_vtt_test.info.yml
@@ -1,0 +1,5 @@
+name: 'Islandora VTT test'
+type: module
+description: 'Provides test routes for Islandora VTT.'
+package: Testing
+core_version_requirement: ^10.1 || ^11 || ^12

--- a/tests/modules/islandora_vtt_test/islandora_vtt_test.routing.yml
+++ b/tests/modules/islandora_vtt_test/islandora_vtt_test.routing.yml
@@ -1,0 +1,10 @@
+islandora_vtt_test.media:
+  path: '/islandora-vtt-test/media/{media}'
+  defaults:
+    _controller: '\Drupal\islandora_vtt_test\Controller\IslandoraVttTestController::media'
+  requirements:
+    _access: 'TRUE'
+  options:
+    parameters:
+      media:
+        type: entity:media

--- a/tests/modules/islandora_vtt_test/src/Controller/IslandoraVttTestController.php
+++ b/tests/modules/islandora_vtt_test/src/Controller/IslandoraVttTestController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\islandora_vtt_test\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\media\MediaInterface;
+
+/**
+ * Provides test routes for Islandora VTT.
+ */
+class IslandoraVttTestController extends ControllerBase {
+
+  /**
+   * Renders a media entity in full mode.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   The media entity.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function media(MediaInterface $media): array {
+    return $this->entityTypeManager()
+      ->getViewBuilder('media')
+      ->view($media, 'full');
+  }
+
+}

--- a/tests/src/FunctionalJavascript/VttTranscriptViewerTest.php
+++ b/tests/src/FunctionalJavascript/VttTranscriptViewerTest.php
@@ -77,6 +77,7 @@ class VttTranscriptViewerTest extends WebDriverTestBase {
 
     $this->drupalGet($media->toUrl());
     $this->ensurePlayerElement();
+    $this->loadTranscriptViewer();
     $this->assertTrue($this->assertSession()->waitForText('Single English transcript'));
 
     $this->assertSession()->elementExists('css', '#vttLanguageControl.d-none');
@@ -95,6 +96,7 @@ class VttTranscriptViewerTest extends WebDriverTestBase {
 
     $this->drupalGet($media->toUrl());
     $this->ensurePlayerElement();
+    $this->loadTranscriptViewer();
     $this->assertTrue($this->assertSession()->waitForText('Multi English transcript'));
 
     $this->assertSession()->elementExists('css', '#vttLanguageControl:not(.d-none)');
@@ -415,6 +417,17 @@ class VttTranscriptViewerTest extends WebDriverTestBase {
       if (!document.querySelector('video')) {
         document.body.insertAdjacentHTML('afterbegin', '<video controls></video>');
       }
+    JS);
+  }
+
+  /**
+   * Starts the transcript viewer after the synthetic player exists.
+   */
+  protected function loadTranscriptViewer(): void {
+    $this->assertNotEmpty($this->getSession()->evaluateScript('drupalSettings.vttTranscripts || []'));
+    $this->getSession()->executeScript(<<<'JS'
+      Drupal.behaviors.islandoraVtt.buildLanguageControl(drupalSettings.vttTranscripts);
+      Drupal.behaviors.islandoraVtt.loadTranscript(drupalSettings.vttTranscripts[0]);
     JS);
   }
 

--- a/tests/src/FunctionalJavascript/VttTranscriptViewerTest.php
+++ b/tests/src/FunctionalJavascript/VttTranscriptViewerTest.php
@@ -1,0 +1,435 @@
+<?php
+
+namespace Drupal\Tests\islandora_vtt\FunctionalJavascript;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\media\Entity\Media;
+use Drupal\media\Entity\MediaType;
+use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Tests the VTT transcript viewer.
+ *
+ * @group islandora_vtt
+ */
+class VttTranscriptViewerTest extends WebDriverTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'islandora',
+    'islandora_core_feature',
+    'islandora_text_extraction',
+    'islandora_vtt',
+    'language',
+    'text',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * The Extracted Text media-use term ID.
+   *
+   * @var int
+   */
+  protected int $extractedTextTid;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->ensureMediaBundle('video');
+    $this->ensureMediaBundle('extracted_text');
+    $this->ensureEditedTextField();
+
+    if (!ConfigurableLanguage::load('fr')) {
+      ConfigurableLanguage::createFromLangcode('fr')->save();
+    }
+
+    $account = $this->drupalCreateUser([
+      'access content',
+      'view media',
+    ]);
+    $this->drupalLogin($account);
+
+    $this->extractedTextTid = $this->getExtractedTextTid();
+  }
+
+  /**
+   * Tests a single-language transcript hides language selection.
+   */
+  public function testSingleLanguageTranscriptCanBeDownloaded(): void {
+    $node = $this->createIslandoraObject('Single-language object');
+    $media = $this->createPlayableMedia($node, 'Single-language video');
+    $this->createTranscriptMedia($node, 'en', 'single-en.vtt', 'Single English transcript');
+
+    $this->drupalGet($media->toUrl());
+    $this->ensurePlayerElement();
+    $this->assertTrue($this->assertSession()->waitForText('Single English transcript'));
+
+    $this->assertSession()->elementExists('css', '#vttLanguageControl.d-none');
+    $this->assertSession()->elementTextEquals('css', '#vttDownloadBtn', 'Download transcript');
+    $this->assertDownloadContains('Single English transcript');
+  }
+
+  /**
+   * Tests multiple transcript languages can be selected and downloaded.
+   */
+  public function testMultipleLanguagesCanBeSelectedAndDownloaded(): void {
+    $node = $this->createIslandoraObject('Multi-language object');
+    $media = $this->createPlayableMedia($node, 'Multi-language video');
+    $this->createTranscriptMedia($node, 'en', 'multi-en.vtt', 'Multi English transcript');
+    $this->createTranscriptMedia($node, 'fr', 'multi-fr.vtt', 'Transcription francaise');
+
+    $this->drupalGet($media->toUrl());
+    $this->ensurePlayerElement();
+    $this->assertTrue($this->assertSession()->waitForText('Multi English transcript'));
+
+    $this->assertSession()->elementExists('css', '#vttLanguageControl:not(.d-none)');
+    $this->assertSession()->fieldExists('Transcript language');
+
+    $this->getSession()->getPage()->selectFieldOption('Transcript language', 'French');
+    $this->assertTrue($this->assertSession()->waitForText('Transcription francaise'));
+    $this->assertDownloadContains('Transcription francaise');
+  }
+
+  /**
+   * Creates an Islandora object node.
+   *
+   * @param string $title
+   *   The node title.
+   *
+   * @return \Drupal\node\Entity\Node
+   *   The saved node.
+   */
+  protected function createIslandoraObject(string $title): Node {
+    $node = Node::create([
+      'type' => 'islandora_object',
+      'title' => $title,
+      'status' => 1,
+    ]);
+    $node->save();
+
+    return $node;
+  }
+
+  /**
+   * Ensures the media bundle needed by these tests exists.
+   *
+   * @param string $bundle
+   *   The media bundle.
+   */
+  protected function ensureMediaBundle(string $bundle): void {
+    if (MediaType::load($bundle)) {
+      return;
+    }
+
+    $this->ensureMediaFileField();
+    $this->ensureMediaReferenceField('field_media_of', 'node');
+    $this->ensureMediaReferenceField('field_media_use', 'taxonomy_term');
+
+    MediaType::create([
+      'id' => $bundle,
+      'label' => ucfirst(str_replace('_', ' ', $bundle)),
+      'source' => 'file',
+      'source_configuration' => [
+        'source_field' => 'field_media_file',
+      ],
+    ])->save();
+
+    $this->ensureBundleField($bundle, 'field_media_file', 'File', TRUE);
+    $this->ensureBundleField($bundle, 'field_media_of', 'Media of', TRUE);
+    $this->ensureBundleField($bundle, 'field_media_use', 'Media use');
+  }
+
+  /**
+   * Ensures the edited text field expected by islandora_text_extraction exists.
+   */
+  protected function ensureEditedTextField(): void {
+    if (!FieldStorageConfig::loadByName('media', 'field_edited_text')) {
+      FieldStorageConfig::create([
+        'entity_type' => 'media',
+        'field_name' => 'field_edited_text',
+        'type' => 'text_long',
+      ])->save();
+    }
+
+    $this->ensureBundleField('extracted_text', 'field_edited_text', 'Edited text');
+  }
+
+  /**
+   * Ensures the shared media file field storage exists.
+   */
+  protected function ensureMediaFileField(): void {
+    if (FieldStorageConfig::loadByName('media', 'field_media_file')) {
+      return;
+    }
+
+    FieldStorageConfig::create([
+      'entity_type' => 'media',
+      'field_name' => 'field_media_file',
+      'type' => 'file',
+      'settings' => [
+        'target_type' => 'file',
+      ],
+    ])->save();
+  }
+
+  /**
+   * Ensures a shared media entity-reference field storage exists.
+   *
+   * @param string $field_name
+   *   The field name.
+   * @param string $target_type
+   *   The target entity type.
+   */
+  protected function ensureMediaReferenceField(string $field_name, string $target_type): void {
+    if (FieldStorageConfig::loadByName('media', $field_name)) {
+      return;
+    }
+
+    FieldStorageConfig::create([
+      'entity_type' => 'media',
+      'field_name' => $field_name,
+      'type' => 'entity_reference',
+      'settings' => [
+        'target_type' => $target_type,
+      ],
+    ])->save();
+  }
+
+  /**
+   * Ensures a field is attached to a media bundle.
+   *
+   * @param string $bundle
+   *   The media bundle.
+   * @param string $field_name
+   *   The field name.
+   * @param string $label
+   *   The field label.
+   * @param bool $required
+   *   Whether the field is required.
+   */
+  protected function ensureBundleField(
+    string $bundle,
+    string $field_name,
+    string $label,
+    bool $required = FALSE,
+  ): void {
+    if (FieldConfig::loadByName('media', $bundle, $field_name)) {
+      return;
+    }
+
+    FieldConfig::create([
+      'entity_type' => 'media',
+      'bundle' => $bundle,
+      'field_name' => $field_name,
+      'label' => $label,
+      'required' => $required,
+    ])->save();
+  }
+
+  /**
+   * Creates media that renders the transcript viewer.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The Islandora object node.
+   * @param string $name
+   *   The media name.
+   *
+   * @return \Drupal\media\Entity\Media
+   *   The saved media.
+   */
+  protected function createPlayableMedia(Node $node, string $name): Media {
+    $file = $this->createManagedFile('video-fixture.mp4', 'video fixture');
+    $values = [
+      'bundle' => 'video',
+      'name' => $name,
+      'status' => 1,
+      'field_media_of' => [
+        'target_id' => $node->id(),
+      ],
+    ];
+
+    $source_field = $this->getMediaSourceField('video');
+    if ($source_field) {
+      $values[$source_field] = [
+        'target_id' => $file->id(),
+      ];
+    }
+
+    $media = Media::create($values);
+    $media->save();
+
+    return $media;
+  }
+
+  /**
+   * Creates extracted text media for a node.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The Islandora object node.
+   * @param string $langcode
+   *   The media language.
+   * @param string $filename
+   *   The VTT file name.
+   * @param string $cue_text
+   *   The cue text.
+   *
+   * @return \Drupal\media\Entity\Media
+   *   The saved media.
+   */
+  protected function createTranscriptMedia(Node $node, string $langcode, string $filename, string $cue_text): Media {
+    $file = $this->createManagedFile($filename, $this->buildVtt($cue_text));
+    $values = [
+      'bundle' => 'extracted_text',
+      'name' => $filename,
+      'langcode' => $langcode,
+      'status' => 1,
+      'field_media_file' => [
+        'target_id' => $file->id(),
+      ],
+      'field_media_of' => [
+        'target_id' => $node->id(),
+      ],
+      'field_media_use' => [
+        'target_id' => $this->extractedTextTid,
+      ],
+      'field_edited_text' => [
+        'value' => $cue_text,
+      ],
+    ];
+
+    $media = Media::create($values);
+    $media->save();
+
+    return $media;
+  }
+
+  /**
+   * Creates a managed public file.
+   *
+   * @param string $filename
+   *   The filename.
+   * @param string $contents
+   *   The file contents.
+   *
+   * @return \Drupal\file\Entity\File
+   *   The saved file.
+   */
+  protected function createManagedFile(string $filename, string $contents): File {
+    $directory = 'public://islandora-vtt-test';
+    $this->container->get('file_system')->prepareDirectory(
+      $directory,
+      FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS
+    );
+    $uri = $directory . '/' . $filename;
+    file_put_contents($uri, $contents);
+
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => $filename,
+      'status' => 1,
+    ]);
+    $file->save();
+
+    return $file;
+  }
+
+  /**
+   * Builds a minimal VTT file.
+   *
+   * @param string $cue_text
+   *   The cue text.
+   *
+   * @return string
+   *   The VTT contents.
+   */
+  protected function buildVtt(string $cue_text): string {
+    return "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\n{$cue_text}\n";
+  }
+
+  /**
+   * Gets the source field for a media type.
+   *
+   * @param string $bundle
+   *   The media bundle.
+   *
+   * @return string|null
+   *   The source field name, if available.
+   */
+  protected function getMediaSourceField(string $bundle): ?string {
+    $media_type = MediaType::load($bundle);
+    if (!$media_type) {
+      return NULL;
+    }
+
+    $configuration = $media_type->getSource()->getConfiguration();
+    return $configuration['source_field'] ?? NULL;
+  }
+
+  /**
+   * Gets the Extracted Text media-use term ID.
+   *
+   * @return int
+   *   The term ID.
+   */
+  protected function getExtractedTextTid(): int {
+    $terms = $this->container->get('entity_type.manager')
+      ->getStorage('taxonomy_term')
+      ->loadByProperties([
+        'vid' => 'islandora_media_use',
+        'name' => 'Extracted Text',
+      ]);
+
+    if ($term = reset($terms)) {
+      return (int) $term->id();
+    }
+
+    $term = Term::create([
+      'vid' => 'islandora_media_use',
+      'name' => 'Extracted Text',
+    ]);
+    $term->save();
+
+    return (int) $term->id();
+  }
+
+  /**
+   * Adds a player element if the media display does not render one.
+   */
+  protected function ensurePlayerElement(): void {
+    $this->getSession()->executeScript(<<<'JS'
+      if (!document.querySelector('video')) {
+        document.body.insertAdjacentHTML('afterbegin', '<video controls></video>');
+      }
+    JS);
+  }
+
+  /**
+   * Asserts the active download link serves the expected VTT text.
+   *
+   * @param string $expected
+   *   Expected text from the VTT file.
+   */
+  protected function assertDownloadContains(string $expected): void {
+    $href = $this->getSession()->evaluateScript("document.getElementById('vttDownloadBtn').href");
+    $this->assertNotEmpty($href);
+
+    $this->drupalGet($href);
+    $this->assertSession()->pageTextContains($expected);
+  }
+
+}

--- a/tests/src/FunctionalJavascript/VttTranscriptViewerTest.php
+++ b/tests/src/FunctionalJavascript/VttTranscriptViewerTest.php
@@ -27,6 +27,7 @@ class VttTranscriptViewerTest extends WebDriverTestBase {
     'islandora',
     'islandora_core_feature',
     'islandora_text_extraction',
+    'islandora_vtt_test',
     'islandora_vtt',
     'language',
     'text',
@@ -75,7 +76,7 @@ class VttTranscriptViewerTest extends WebDriverTestBase {
     $media = $this->createPlayableMedia($node, 'Single-language video');
     $this->createTranscriptMedia($node, 'en', 'single-en.vtt', 'Single English transcript');
 
-    $this->drupalGet($media->toUrl());
+    $this->drupalGet('/islandora-vtt-test/media/' . $media->id());
     $this->ensurePlayerElement();
     $this->loadTranscriptViewer();
     $this->assertTrue($this->assertSession()->waitForText('Single English transcript'));
@@ -94,7 +95,7 @@ class VttTranscriptViewerTest extends WebDriverTestBase {
     $this->createTranscriptMedia($node, 'en', 'multi-en.vtt', 'Multi English transcript');
     $this->createTranscriptMedia($node, 'fr', 'multi-fr.vtt', 'Transcription francaise');
 
-    $this->drupalGet($media->toUrl());
+    $this->drupalGet('/islandora-vtt-test/media/' . $media->id());
     $this->ensurePlayerElement();
     $this->loadTranscriptViewer();
     $this->assertTrue($this->assertSession()->waitForText('Multi English transcript'));


### PR DESCRIPTION
Replace the single hardcoded transcript lookup with an entity query for all accessible media attached to the current media's node via field_media_of and marked with the Extracted Text Islandora media use. Prefer field_islandora_media_use while retaining a fallback to field_media_use for existing installs.

Expose the available transcript media to the viewer with URL, langcode, language label, and normalized .vtt download filename metadata. The viewer now hides the language selector when there is only one transcript, shows a selector when multiple languages are available, and reloads the transcript/search state when the selected language changes.

Add a Download VTT button that always points at the currently selected transcript media URL. The JavaScript also avoids inserting transcript text as raw HTML while rendering cues and search highlights.
